### PR TITLE
lua: use non-member functions for interop

### DIFF
--- a/resources/process-openmaptiles.lua
+++ b/resources/process-openmaptiles.lua
@@ -49,36 +49,36 @@ aerodromeValues = Set { "international", "public", "regional", "military", "priv
 -- Process node tags
 
 node_keys = { "addr:housenumber","aerialway","aeroway","amenity","barrier","highway","historic","leisure","natural","office","place","railway","shop","sport","tourism","waterway" }
-function node_function(node)
+function node_function()
 	-- Write 'aerodrome_label'
-	local aeroway = node:Find("aeroway")
+	local aeroway = Find("aeroway")
 	if aeroway == "aerodrome" then
-		node:Layer("aerodrome_label", false)
-		SetNameAttributes(node)
-		node:Attribute("iata", node:Find("iata"))
-		SetEleAttributes(node)
-		node:Attribute("icao", node:Find("icao"))
+		Layer("aerodrome_label", false)
+		SetNameAttributes()
+		Attribute("iata", Find("iata"))
+		SetEleAttributes()
+		Attribute("icao", Find("icao"))
 
-		local aerodrome_value = node:Find("aerodrome")
+		local aerodrome_value = Find("aerodrome")
 		local class
 		if aerodromeValues[aerodrome_value] then class = aerodrome_value else class = "other" end
-		node:Attribute("class", class)
+		Attribute("class", class)
 	end
 	-- Write 'housenumber'
-	local housenumber = node:Find("addr:housenumber")
+	local housenumber = Find("addr:housenumber")
 	if housenumber~="" then
-		node:Layer("housenumber", false)
-		node:Attribute("housenumber", housenumber)
+		Layer("housenumber", false)
+		Attribute("housenumber", housenumber)
 	end
 
 	-- Write 'place'
 	-- note that OpenMapTiles has a rank for countries (1-3), states (1-6) and cities (1-10+);
 	--   we could potentially approximate it for cities based on the population tag
-	local place = node:Find("place")
+	local place = Find("place")
 	if place ~= "" then
 		local rank = nil
 		local mz = 13
-		local pop = tonumber(node:Find("population")) or 0
+		local pop = tonumber(Find("population")) or 0
 
 		if     place == "continent"     then mz=0
 		elseif place == "country"       then
@@ -97,32 +97,32 @@ function node_function(node)
 		elseif place == "locality"      then mz=13
 		end
 
-		node:Layer("place", false)
-		node:Attribute("class", place)
-		node:MinZoom(mz)
-		if rank then node:AttributeNumeric("rank", rank) end
-		if place=="country" then node:Attribute("iso_a2", node:Find("ISO3166-1:alpha2")) end
-		SetNameAttributes(node)
+		Layer("place", false)
+		Attribute("class", place)
+		MinZoom(mz)
+		if rank then AttributeNumeric("rank", rank) end
+		if place=="country" then Attribute("iso_a2", Find("ISO3166-1:alpha2")) end
+		SetNameAttributes()
 		return
 	end
 
 	-- Write 'poi'
-	local rank, class, subclass = GetPOIRank(node)
-	if rank then WritePOI(node,class,subclass,rank) end
+	local rank, class, subclass = GetPOIRank()
+	if rank then WritePOI(class,subclass,rank) end
 
 	-- Write 'mountain_peak' and 'water_name'
-	local natural = node:Find("natural")
+	local natural = Find("natural")
 	if natural == "peak" or natural == "volcano" then
-		node:Layer("mountain_peak", false)
-		SetEleAttributes(node)
-		node:AttributeNumeric("rank", 1)
-		node:Attribute("class", natural)
-		SetNameAttributes(node)
+		Layer("mountain_peak", false)
+		SetEleAttributes()
+		AttributeNumeric("rank", 1)
+		Attribute("class", natural)
+		SetNameAttributes()
 		return
 	end
 	if natural == "bay" then
-		node:Layer("water_name", false)
-		SetNameAttributes(node)
+		Layer("water_name", false)
+		SetNameAttributes()
 		return
 	end
 end
@@ -208,45 +208,45 @@ waterwayClasses = Set { "stream", "river", "canal", "drain", "ditch" }
 
 -- Scan relations for use in ways
 
-function relation_scan_function(relation)
-	if relation:Find("type")=="boundary" and relation:Find("boundary")=="administrative" then
-		relation:Accept()
+function relation_scan_function()
+	if Find("type")=="boundary" and Find("boundary")=="administrative" then
+		Accept()
 	end
 end
 
 -- Process way tags
 
-function way_function(way)
-	local route    = way:Find("route")
-	local highway  = way:Find("highway")
-	local waterway = way:Find("waterway")
-	local water    = way:Find("water")
-	local building = way:Find("building")
-	local natural  = way:Find("natural")
-	local historic = way:Find("historic")
-	local landuse  = way:Find("landuse")
-	local leisure  = way:Find("leisure")
-	local amenity  = way:Find("amenity")
-	local aeroway  = way:Find("aeroway")
-	local railway  = way:Find("railway")
-	local service  = way:Find("service")
-	local sport    = way:Find("sport")
-	local shop     = way:Find("shop")
-	local tourism  = way:Find("tourism")
-	local man_made = way:Find("man_made")
-	local boundary = way:Find("boundary")
-	local isClosed = way:IsClosed()
-	local housenumber = way:Find("addr:housenumber")
+function way_function()
+	local route    = Find("route")
+	local highway  = Find("highway")
+	local waterway = Find("waterway")
+	local water    = Find("water")
+	local building = Find("building")
+	local natural  = Find("natural")
+	local historic = Find("historic")
+	local landuse  = Find("landuse")
+	local leisure  = Find("leisure")
+	local amenity  = Find("amenity")
+	local aeroway  = Find("aeroway")
+	local railway  = Find("railway")
+	local service  = Find("service")
+	local sport    = Find("sport")
+	local shop     = Find("shop")
+	local tourism  = Find("tourism")
+	local man_made = Find("man_made")
+	local boundary = Find("boundary")
+	local isClosed = IsClosed()
+	local housenumber = Find("addr:housenumber")
 	local write_name = false
-	local construction = way:Find("construction")
+	local construction = Find("construction")
 
 	-- Miscellaneous preprocessing
-	if way:Find("disused") == "yes" then return end
-	if boundary~="" and way:Find("protection_title")=="National Forest" and way:Find("operator")=="United States Forest Service" then return end
+	if Find("disused") == "yes" then return end
+	if boundary~="" and Find("protection_title")=="National Forest" and Find("operator")=="United States Forest Service" then return end
 	if highway == "proposed" then return end
 	if aerowayBuildings[aeroway] then building="yes"; aeroway="" end
 	if landuse == "field" then landuse = "farmland" end
-	if landuse == "meadow" and way:Find("meadow")=="agricultural" then landuse="farmland" end
+	if landuse == "meadow" and Find("meadow")=="agricultural" then landuse="farmland" end
 
 	-- Boundaries within relations
 	-- note that we process administrative boundaries as properties on ways, rather than as single relation geometries,
@@ -254,21 +254,21 @@ function way_function(way)
 	local admin_level = 11
 	local isBoundary = false
 	while true do
-		local rel = way:NextRelation()
+		local rel = NextRelation()
 		if not rel then break end
 		isBoundary = true
-		admin_level = math.min(admin_level, tonumber(way:FindInRelation("admin_level")) or 11)
+		admin_level = math.min(admin_level, tonumber(FindInRelation("admin_level")) or 11)
 	end
 
 	-- Boundaries in ways
 	if boundary=="administrative" then
-		admin_level = math.min(admin_level, tonumber(way:Find("admin_level")) or 11)
+		admin_level = math.min(admin_level, tonumber(Find("admin_level")) or 11)
 		isBoundary = true
 	end
 
 	-- Administrative boundaries
 	-- https://openmaptiles.org/schema/#boundary
-	if isBoundary and not (way:Find("maritime")=="yes") then
+	if isBoundary and not (Find("maritime")=="yes") then
 		local mz = 0
 		if     admin_level>=3 and admin_level<5 then mz=4
 		elseif admin_level>=5 and admin_level<7 then mz=8
@@ -276,22 +276,22 @@ function way_function(way)
 		elseif admin_level>=8 then mz=12
 		end
 
-		way:Layer("boundary",false)
-		way:AttributeNumeric("admin_level", admin_level)
-		way:MinZoom(mz)
+		Layer("boundary",false)
+		AttributeNumeric("admin_level", admin_level)
+		MinZoom(mz)
 		-- disputed status (0 or 1). some styles need to have the 0 to show it.
-		local disputed = way:Find("disputed")
+		local disputed = Find("disputed")
 		if disputed=="yes" then
-			way:AttributeNumeric("disputed", 1)
+			AttributeNumeric("disputed", 1)
 		else
-			way:AttributeNumeric("disputed", 0)
+			AttributeNumeric("disputed", 0)
 		end
 	end
 
 	-- Roads ('transportation' and 'transportation_name', plus 'transportation_name_detail')
 	if highway~="" then
-		local access = way:Find("access")
-		local surface = way:Find("surface")
+		local access = Find("access")
+		local surface = Find("surface")
 
 		local h = highway
 		local minzoom = 99
@@ -332,26 +332,26 @@ function way_function(way)
 
 		-- Write to layer
 		if minzoom <= 14 then
-			way:Layer(layer, false)
-			way:MinZoom(minzoom)
-			SetZOrder(way)
-			way:Attribute("class", h)
-			SetBrunnelAttributes(way)
-			if ramp then way:AttributeNumeric("ramp",1) end
-			if access=="private" or access=="no" then way:Attribute("access", "no") end
-			if pavedValues[surface] then way:Attribute("surface", "paved") end
-			if unpavedValues[surface] then way:Attribute("surface", "unpaved") end
-			if way:Holds("bicycle") then way:Attribute("bicycle", way:Find("bicycle")) end
-			if way:Holds("foot") then way:Attribute("foot", way:Find("foot")) end
-			if way:Holds("horse") then way:Attribute("horse", way:Find("horse")) end
-			if way:Holds("mtb:scale") then way:Attribute("mtb_scale", way:Find("mtb:scale")) end
+			Layer(layer, false)
+			MinZoom(minzoom)
+			SetZOrder()
+			Attribute("class", h)
+			SetBrunnelAttributes()
+			if ramp then AttributeNumeric("ramp",1) end
+			if access=="private" or access=="no" then Attribute("access", "no") end
+			if pavedValues[surface] then Attribute("surface", "paved") end
+			if unpavedValues[surface] then Attribute("surface", "unpaved") end
+			if Holds("bicycle") then Attribute("bicycle", Find("bicycle")) end
+			if Holds("foot") then Attribute("foot", Find("foot")) end
+			if Holds("horse") then Attribute("horse", Find("horse")) end
+			if Holds("mtb:scale") then Attribute("mtb_scale", Find("mtb:scale")) end
 
 			-- Service
-			if highway == "service" and service ~="" then way:Attribute("service", service) end
+			if highway == "service" and service ~="" then Attribute("service", service) end
 
-			local oneway = way:Find("oneway")
+			local oneway = Find("oneway")
 			if oneway == "yes" or oneway == "1" then
-				way:AttributeNumeric("oneway",1)
+				AttributeNumeric("oneway",1)
 			end
 			if oneway == "-1" then
 				-- **** TODO
@@ -362,152 +362,152 @@ function way_function(way)
 				minzoom = 8
 			end
 			if highway == "motorway" or highway == "trunk" then
-				way:Layer("transportation_name", false)
-				way:MinZoom(minzoom)
+				Layer("transportation_name", false)
+				MinZoom(minzoom)
 			elseif h == "minor" or h == "track" or h == "path" or h == "service" then
-				way:Layer("transportation_name_detail", false)
-				way:MinZoom(minzoom)
+				Layer("transportation_name_detail", false)
+				MinZoom(minzoom)
 			else
-				way:Layer("transportation_name_mid", false)
-				way:MinZoom(minzoom)
+				Layer("transportation_name_mid", false)
+				MinZoom(minzoom)
 			end
-			SetNameAttributes(way)
-			way:Attribute("class",h)
-			way:Attribute("network","road") -- **** could also be us-interstate, us-highway, us-state
-			if h~=highway then way:Attribute("subclass",highway) end
-			local ref = way:Find("ref")
+			SetNameAttributes()
+			Attribute("class",h)
+			Attribute("network","road") -- **** could also be us-interstate, us-highway, us-state
+			if h~=highway then Attribute("subclass",highway) end
+			local ref = Find("ref")
 			if ref~="" then
-				way:Attribute("ref",ref)
-				way:AttributeNumeric("ref_length",ref:len())
+				Attribute("ref",ref)
+				AttributeNumeric("ref_length",ref:len())
 			end
 		end
 	end
 
 	-- Railways ('transportation' and 'transportation_name', plus 'transportation_name_detail')
 	if railway~="" then
-		way:Layer("transportation", false)
-		way:Attribute("class", railway)
-		SetZOrder(way)
-		SetBrunnelAttributes(way)
+		Layer("transportation", false)
+		Attribute("class", railway)
+		SetZOrder()
+		SetBrunnelAttributes()
 		if service~="" then
-			way:Attribute("service", service)
-			way:MinZoom(12)
+			Attribute("service", service)
+			MinZoom(12)
 		else
-			way:MinZoom(9)
+			MinZoom(9)
 		end
 
-		way:Layer("transportation_name", false)
-		SetNameAttributes(way)
-		way:MinZoom(14)
-		way:Attribute("class", "rail")
+		Layer("transportation_name", false)
+		SetNameAttributes()
+		MinZoom(14)
+		Attribute("class", "rail")
 	end
 
 	-- Pier
 	if man_made=="pier" then
-		way:Layer("transportation", isClosed)
-		SetZOrder(way)
-		way:Attribute("class", "pier")
-		SetMinZoomByArea(way)
+		Layer("transportation", isClosed)
+		SetZOrder()
+		Attribute("class", "pier")
+		SetMinZoomByArea()
 	end
 
 	-- 'Ferry'
 	if route=="ferry" then
-		way:Layer("transportation", false)
-		way:Attribute("class", "ferry")
-		SetZOrder(way)
-		way:MinZoom(9)
-		SetBrunnelAttributes(way)
+		Layer("transportation", false)
+		Attribute("class", "ferry")
+		SetZOrder()
+		MinZoom(9)
+		SetBrunnelAttributes()
 
-		way:Layer("transportation_name", false)
-		SetNameAttributes(way)
-		way:MinZoom(12)
-		way:Attribute("class", "ferry")
+		Layer("transportation_name", false)
+		SetNameAttributes()
+		MinZoom(12)
+		Attribute("class", "ferry")
 	end
 
 	-- 'Aeroway'
 	if aeroway~="" then
-		way:Layer("aeroway", isClosed)
-		way:Attribute("class",aeroway)
-		way:Attribute("ref",way:Find("ref"))
+		Layer("aeroway", isClosed)
+		Attribute("class",aeroway)
+		Attribute("ref",Find("ref"))
 		write_name = true
 	end
 
 	-- 'aerodrome_label'
 	if aeroway=="aerodrome" then
-	 	way:LayerAsCentroid("aerodrome_label")
-	 	SetNameAttributes(way)
-	 	way:Attribute("iata", way:Find("iata"))
-  		SetEleAttributes(way)
- 	 	way:Attribute("icao", way:Find("icao"))
+	 	LayerAsCentroid("aerodrome_label")
+	 	SetNameAttributes()
+	 	Attribute("iata", Find("iata"))
+  		SetEleAttributes()
+ 	 	Attribute("icao", Find("icao"))
 
- 	 	local aerodrome = way:Find(aeroway)
+ 	 	local aerodrome = Find(aeroway)
  	 	local class
  	 	if aerodromeValues[aerodrome] then class = aerodrome else class = "other" end
- 	 	way:Attribute("class", class)
+ 	 	Attribute("class", class)
 	end
 
 	-- Set 'waterway' and associated
 	if waterwayClasses[waterway] and not isClosed then
-		if waterway == "river" and way:Holds("name") then
-			way:Layer("waterway", false)
+		if waterway == "river" and Holds("name") then
+			Layer("waterway", false)
 		else
-			way:Layer("waterway_detail", false)
+			Layer("waterway_detail", false)
 		end
-		if way:Find("intermittent")=="yes" then way:AttributeNumeric("intermittent", 1) else way:AttributeNumeric("intermittent", 0) end
-		way:Attribute("class", waterway)
-		SetNameAttributes(way)
-		SetBrunnelAttributes(way)
-	elseif waterway == "boatyard"  then way:Layer("landuse", isClosed); way:Attribute("class", "industrial"); way:MinZoom(12)
-	elseif waterway == "dam"       then way:Layer("building",isClosed)
-	elseif waterway == "fuel"      then way:Layer("landuse", isClosed); way:Attribute("class", "industrial"); way:MinZoom(14)
+		if Find("intermittent")=="yes" then AttributeNumeric("intermittent", 1) else AttributeNumeric("intermittent", 0) end
+		Attribute("class", waterway)
+		SetNameAttributes()
+		SetBrunnelAttributes()
+	elseif waterway == "boatyard"  then Layer("landuse", isClosed); Attribute("class", "industrial"); MinZoom(12)
+	elseif waterway == "dam"       then Layer("building",isClosed)
+	elseif waterway == "fuel"      then Layer("landuse", isClosed); Attribute("class", "industrial"); MinZoom(14)
 	end
 	-- Set names on rivers
 	if waterwayClasses[waterway] and not isClosed then
-		if waterway == "river" and way:Holds("name") then
-			way:Layer("water_name", false)
+		if waterway == "river" and Holds("name") then
+			Layer("water_name", false)
 		else
-			way:Layer("water_name_detail", false)
-			way:MinZoom(14)
+			Layer("water_name_detail", false)
+			MinZoom(14)
 		end
-		way:Attribute("class", waterway)
-		SetNameAttributes(way)
+		Attribute("class", waterway)
+		SetNameAttributes()
 	end
 
 	-- Set 'building' and associated
 	if building~="" then
-		way:Layer("building", true)
-		SetBuildingHeightAttributes(way)
-		SetMinZoomByArea(way)
+		Layer("building", true)
+		SetBuildingHeightAttributes()
+		SetMinZoomByArea()
 	end
 
 	-- Set 'housenumber'
 	if housenumber~="" then
-		way:LayerAsCentroid("housenumber", false)
-		way:Attribute("housenumber", housenumber)
+		LayerAsCentroid("housenumber", false)
+		Attribute("housenumber", housenumber)
 	end
 
 	-- Set 'water'
 	if natural=="water" or natural=="bay" or leisure=="swimming_pool" or landuse=="reservoir" or landuse=="basin" or waterClasses[waterway] then
-		if way:Find("covered")=="yes" or not isClosed then return end
+		if Find("covered")=="yes" or not isClosed then return end
 		local class="lake"; if natural=="bay" then class="ocean" elseif waterway~="" then class="river" end
-		if class=="lake" and way:Find("wikidata")=="Q192770" then return end
-		if class=="ocean" and isClosed and (way:AreaIntersecting("ocean")/way:Area() > 0.98) then return end
-		way:Layer("water",true)
-		SetMinZoomByArea(way)
-		way:Attribute("class",class)
+		if class=="lake" and Find("wikidata")=="Q192770" then return end
+		if class=="ocean" and isClosed and (AreaIntersecting("ocean")/Area() > 0.98) then return end
+		Layer("water",true)
+		SetMinZoomByArea()
+		Attribute("class",class)
 
-		if way:Find("intermittent")=="yes" then way:Attribute("intermittent",1) end
+		if Find("intermittent")=="yes" then Attribute("intermittent",1) end
 		-- we only want to show the names of actual lakes not every man-made basin that probably doesn't even have a name other than "basin"
 		-- examples for which we don't want to show a name:
 		--  https://www.openstreetmap.org/way/25958687
 		--  https://www.openstreetmap.org/way/27201902
 		--  https://www.openstreetmap.org/way/25309134
 		--  https://www.openstreetmap.org/way/24579306
-		if way:Holds("name") and natural=="water" and water ~= "basin" and water ~= "wastewater" then
-			way:LayerAsCentroid("water_name_detail")
-			SetNameAttributes(way)
-			SetMinZoomByArea(way)
-			way:Attribute("class", class)
+		if Holds("name") and natural=="water" and water ~= "basin" and water ~= "wastewater" then
+			LayerAsCentroid("water_name_detail")
+			SetNameAttributes()
+			SetMinZoomByArea()
+			Attribute("class", class)
 		end
 
 		return -- in case we get any landuse processing
@@ -518,11 +518,11 @@ function way_function(way)
 	if l=="" then l=natural end
 	if l=="" then l=leisure end
 	if landcoverKeys[l] then
-		way:Layer("landcover", true)
-		SetMinZoomByArea(way)
-		way:Attribute("class", landcoverKeys[l])
-		if l=="wetland" then way:Attribute("subclass", way:Find("wetland"))
-		else way:Attribute("subclass", l) end
+		Layer("landcover", true)
+		SetMinZoomByArea()
+		Attribute("class", landcoverKeys[l])
+		if l=="wetland" then Attribute("subclass", Find("wetland"))
+		else Attribute("subclass", l) end
 		write_name = true
 
 	-- Set 'landuse'
@@ -530,31 +530,31 @@ function way_function(way)
 		if l=="" then l=amenity end
 		if l=="" then l=tourism end
 		if landuseKeys[l] then
-			way:Layer("landuse", true)
-			way:Attribute("class", l)
+			Layer("landuse", true)
+			Attribute("class", l)
 			if l=="residential" then
-				if way:Area()<ZRES8^2 then way:MinZoom(8)
-				else SetMinZoomByArea(way) end
-			else way:MinZoom(11) end
+				if Area()<ZRES8^2 then MinZoom(8)
+				else SetMinZoomByArea() end
+			else MinZoom(11) end
 			write_name = true
 		end
 	end
 
 	-- Parks
 	-- **** name?
-	if     boundary=="national_park" then way:Layer("park",true); way:Attribute("class",boundary); SetNameAttributes(way)
-	elseif leisure=="nature_reserve" then way:Layer("park",true); way:Attribute("class",leisure ); SetNameAttributes(way) end
+	if     boundary=="national_park" then Layer("park",true); Attribute("class",boundary); SetNameAttributes()
+	elseif leisure=="nature_reserve" then Layer("park",true); Attribute("class",leisure ); SetNameAttributes() end
 
 	-- POIs ('poi' and 'poi_detail')
-	local rank, class, subclass = GetPOIRank(way)
-	if rank then WritePOI(way,class,subclass,rank); return end
+	local rank, class, subclass = GetPOIRank()
+	if rank then WritePOI(class,subclass,rank); return end
 
 	-- Catch-all
-	if (building~="" or write_name) and way:Holds("name") then
-		way:LayerAsCentroid("poi_detail")
-		SetNameAttributes(way)
+	if (building~="" or write_name) and Holds("name") then
+		LayerAsCentroid("poi_detail")
+		SetNameAttributes()
 		if write_name then rank=6 else rank=25 end
-		way:AttributeNumeric("rank", rank)
+		AttributeNumeric("rank", rank)
 	end
 end
 
@@ -575,112 +575,112 @@ end
 -- Common functions
 
 -- Write a way centroid to POI layer
-function WritePOI(obj,class,subclass,rank)
+function WritePOI(class,subclass,rank)
 	local layer = "poi"
 	if rank>4 then layer="poi_detail" end
-	obj:LayerAsCentroid(layer)
-	SetNameAttributes(obj)
-	obj:AttributeNumeric("rank", rank)
-	obj:Attribute("class", class)
-	obj:Attribute("subclass", subclass)
+	LayerAsCentroid(layer)
+	SetNameAttributes()
+	AttributeNumeric("rank", rank)
+	Attribute("class", class)
+	Attribute("subclass", subclass)
 	-- layer defaults to 0
-	obj:AttributeNumeric("layer", tonumber(obj:Find("layer")) or 0)
+	AttributeNumeric("layer", tonumber(Find("layer")) or 0)
 	-- indoor defaults to false
-	obj:AttributeBoolean("indoor", (obj:Find("indoor") == "yes"))
+	AttributeBoolean("indoor", (Find("indoor") == "yes"))
 	-- level has no default
-	local level = tonumber(obj:Find("level"))
+	local level = tonumber(Find("level"))
 	if level then
-		obj:AttributeNumeric("level", level)
+		AttributeNumeric("level", level)
 	end
 end
 
 -- Set name attributes on any object
-function SetNameAttributes(obj)
-	local name = obj:Find("name"), iname
+function SetNameAttributes()
+	local name = Find("name"), iname
 	local main_written = name
 	-- if we have a preferred language, then write that (if available), and additionally write the base name tag
-	if preferred_language and obj:Holds("name:"..preferred_language) then
-		iname = obj:Find("name:"..preferred_language)
-		obj:Attribute(preferred_language_attribute, iname)
+	if preferred_language and Holds("name:"..preferred_language) then
+		iname = Find("name:"..preferred_language)
+		Attribute(preferred_language_attribute, iname)
 		if iname~=name and default_language_attribute then
-			obj:Attribute(default_language_attribute, name)
+			Attribute(default_language_attribute, name)
 		else main_written = iname end
 	else
-		obj:Attribute(preferred_language_attribute, name)
+		Attribute(preferred_language_attribute, name)
 	end
 	-- then set any additional languages
 	for i,lang in ipairs(additional_languages) do
-		iname = obj:Find("name:"..lang)
+		iname = Find("name:"..lang)
 		if iname=="" then iname=name end
-		if iname~=main_written then obj:Attribute("name:"..lang, iname) end
+		if iname~=main_written then Attribute("name:"..lang, iname) end
 	end
 end
 
 -- Set ele and ele_ft on any object
-function SetEleAttributes(obj)
-    local ele = obj:Find("ele")
+function SetEleAttributes()
+    local ele = Find("ele")
 	if ele ~= "" then
 		local meter = math.floor(tonumber(ele) or 0)
 		local feet = math.floor(meter * 3.2808399)
-		obj:AttributeNumeric("ele", meter)
-		obj:AttributeNumeric("ele_ft", feet)
+		AttributeNumeric("ele", meter)
+		AttributeNumeric("ele_ft", feet)
     end
 end
 
-function SetBrunnelAttributes(obj)
-	if     obj:Find("bridge") == "yes" then obj:Attribute("brunnel", "bridge")
-	elseif obj:Find("tunnel") == "yes" then obj:Attribute("brunnel", "tunnel")
-	elseif obj:Find("ford")   == "yes" then obj:Attribute("brunnel", "ford")
+function SetBrunnelAttributes()
+	if     Find("bridge") == "yes" then Attribute("brunnel", "bridge")
+	elseif Find("tunnel") == "yes" then Attribute("brunnel", "tunnel")
+	elseif Find("ford")   == "yes" then Attribute("brunnel", "ford")
 	end
 end
 
 -- Set minimum zoom level by area
-function SetMinZoomByArea(way)
-	local area=way:Area()
-	if     area>ZRES5^2  then way:MinZoom(6)
-	elseif area>ZRES6^2  then way:MinZoom(7)
-	elseif area>ZRES7^2  then way:MinZoom(8)
-	elseif area>ZRES8^2  then way:MinZoom(9)
-	elseif area>ZRES9^2  then way:MinZoom(10)
-	elseif area>ZRES10^2 then way:MinZoom(11)
-	elseif area>ZRES11^2 then way:MinZoom(12)
-	elseif area>ZRES12^2 then way:MinZoom(13)
-	else                      way:MinZoom(14) end
+function SetMinZoomByArea()
+	local area=Area()
+	if     area>ZRES5^2  then MinZoom(6)
+	elseif area>ZRES6^2  then MinZoom(7)
+	elseif area>ZRES7^2  then MinZoom(8)
+	elseif area>ZRES8^2  then MinZoom(9)
+	elseif area>ZRES9^2  then MinZoom(10)
+	elseif area>ZRES10^2 then MinZoom(11)
+	elseif area>ZRES11^2 then MinZoom(12)
+	elseif area>ZRES12^2 then MinZoom(13)
+	else                      MinZoom(14) end
 end
 
 -- Calculate POIs (typically rank 1-4 go to 'poi' z12-14, rank 5+ to 'poi_detail' z14)
 -- returns rank, class, subclass
-function GetPOIRank(obj)
+function GetPOIRank()
 	local k,list,v,class,rank
 
 	-- Can we find the tag?
 	for k,list in pairs(poiTags) do
-		if list[obj:Find(k)] then
-			v = obj:Find(k)	-- k/v are the OSM tag pair
+		if list[Find(k)] then
+			v = Find(k)	-- k/v are the OSM tag pair
 			class = poiClasses[v] or k
 			rank  = poiClassRanks[class] or 25
 			subclassKey = poiSubClasses[v]
 			if subclassKey then
 				class = v
-				v = obj:Find(subclassKey)
+				v = Find(subclassKey)
 			end
 			return rank, class, v
 		end
 	end
 
 	-- Catch-all for shops
-	local shop = obj:Find("shop")
+	local shop = Find("shop")
 	if shop~="" then return poiClassRanks['shop'], "shop", shop end
 
 	-- Nothing found
 	return nil,nil,nil
 end
 
-function SetBuildingHeightAttributes(way)
-	local height = tonumber(way:Find("height"), 10)
-	local minHeight = tonumber(way:Find("min_height"), 10)
-	local levels = tonumber(way:Find("building:levels"), 10)
-	local minLevel = tonumber(way:Find("building:min_level"), 10)
+function SetBuildingHeightAttributes()
+	local height = tonumber(Find("height"), 10)
+	local minHeight = tonumber(Find("min_height"), 10)
+	local levels = tonumber(Find("building:levels"), 10)
+	local minLevel = tonumber(Find("building:min_level"), 10)
 
 	local renderHeight = BUILDING_FLOOR_HEIGHT
 	if height or levels then
@@ -696,17 +696,17 @@ function SetBuildingHeightAttributes(way)
 		renderHeight = renderHeight + renderMinHeight
 	end
 
-	way:AttributeNumeric("render_height", renderHeight)
-	way:AttributeNumeric("render_min_height", renderMinHeight)
+	AttributeNumeric("render_height", renderHeight)
+	AttributeNumeric("render_min_height", renderMinHeight)
 end
 
 -- Implement z_order as calculated by Imposm
 -- See https://imposm.org/docs/imposm3/latest/mapping.html#wayzorder for details.
-function SetZOrder(way)
-	local highway = way:Find("highway")
-	local layer = tonumber(way:Find("layer"))
-	local bridge = way:Find("bridge")
-	local tunnel = way:Find("tunnel")
+function SetZOrder()
+	local highway = Find("highway")
+	local layer = tonumber(Find("layer"))
+	local bridge = Find("bridge")
+	local tunnel = Find("tunnel")
 	local zOrder = 0
 	if bridge ~= "" and bridge ~= "no" then
 		zOrder = zOrder + 10
@@ -737,7 +737,7 @@ function SetZOrder(way)
 		hwClass = 3
 	end
 	zOrder = zOrder + hwClass
-	way:ZOrder(zOrder)
+	ZOrder(zOrder)
 end
 
 -- ==========================================================

--- a/src/osm_lua_processing.cpp
+++ b/src/osm_lua_processing.cpp
@@ -6,6 +6,31 @@
 using namespace std;
 
 thread_local kaguya::State *g_luaState = nullptr;
+thread_local OsmLuaProcessing* osmLuaProcessing = nullptr;
+
+std::string rawId() { return osmLuaProcessing->Id(); }
+bool rawHolds(const std::string& key) { return osmLuaProcessing->Holds(key); }
+const std::string& rawFind(const std::string& key) { return osmLuaProcessing->Find(key); }
+std::vector<std::string> rawFindIntersecting(const std::string &layerName) { return osmLuaProcessing->FindIntersecting(layerName); }
+bool rawIntersects(const std::string& layerName) { return osmLuaProcessing->Intersects(layerName); }
+std::vector<std::string> rawFindCovering(const std::string& layerName) { return osmLuaProcessing->FindCovering(layerName); }
+bool rawCoveredBy(const std::string& layerName) { return osmLuaProcessing->CoveredBy(layerName); }
+bool rawIsClosed() { return osmLuaProcessing->IsClosed(); }
+double rawArea() { return osmLuaProcessing->Area(); }
+double rawLength() { return osmLuaProcessing->Length(); }
+std::vector<double> Centroid() { return osmLuaProcessing->Centroid(); }
+void rawLayer(const std::string& layerName, bool area) { return osmLuaProcessing->Layer(layerName, area); }
+void rawLayerAsCentroid(const std::string &layerName) { return osmLuaProcessing->LayerAsCentroid(layerName); }
+void rawMinZoom(const double z) { return osmLuaProcessing->MinZoom(z); }
+void rawZOrder(const double z) { return osmLuaProcessing->ZOrder(z); }
+kaguya::optional<int> rawNextRelation() { return osmLuaProcessing->NextRelation(); }
+void rawRestartRelations() { return osmLuaProcessing->RestartRelations(); }
+std::string rawFindInRelation(const std::string& key) { return osmLuaProcessing->FindInRelation(key); }
+void rawAccept() { return osmLuaProcessing->Accept(); }
+double rawAreaIntersecting(const std::string& layerName) { return osmLuaProcessing->AreaIntersecting(layerName); }
+std::vector<double> rawCentroid() { return osmLuaProcessing->Centroid(); }
+
+
 bool supportsRemappingShapefiles = false;
 const std::string EMPTY_STRING = "";
 
@@ -38,31 +63,41 @@ OsmLuaProcessing::OsmLuaProcessing(
 	g_luaState = &luaState;
 	luaState.setErrorHandler(lua_error_handler);
 	luaState.dofile(luaFile.c_str());
-	luaState["OSM"].setClass(kaguya::UserdataMetatable<OsmLuaProcessing>()
-		.addFunction("Id", &OsmLuaProcessing::Id)
-		.addFunction("Holds", &OsmLuaProcessing::Holds)
-		.addFunction("Find", &OsmLuaProcessing::Find)
-		.addFunction("FindIntersecting", &OsmLuaProcessing::FindIntersecting)
-		.addFunction("Intersects", &OsmLuaProcessing::Intersects)
-		.addFunction("FindCovering", &OsmLuaProcessing::FindCovering)
-		.addFunction("CoveredBy", &OsmLuaProcessing::CoveredBy)
-		.addFunction("IsClosed", &OsmLuaProcessing::IsClosed)
-		.addFunction("Area", &OsmLuaProcessing::Area)
-		.addFunction("AreaIntersecting", &OsmLuaProcessing::AreaIntersecting)
-		.addFunction("Length", &OsmLuaProcessing::Length)
-		.addFunction("Centroid", &OsmLuaProcessing::Centroid)
-		.addFunction("Layer", &OsmLuaProcessing::Layer)
-		.addFunction("LayerAsCentroid", &OsmLuaProcessing::LayerAsCentroid)
-		.addOverloadedFunctions("Attribute", &OsmLuaProcessing::Attribute, &OsmLuaProcessing::AttributeWithMinZoom)
-		.addOverloadedFunctions("AttributeNumeric", &OsmLuaProcessing::AttributeNumeric, &OsmLuaProcessing::AttributeNumericWithMinZoom)
-		.addOverloadedFunctions("AttributeBoolean", &OsmLuaProcessing::AttributeBoolean, &OsmLuaProcessing::AttributeBooleanWithMinZoom)
-		.addFunction("MinZoom", &OsmLuaProcessing::MinZoom)
-		.addFunction("ZOrder", &OsmLuaProcessing::ZOrder)
-		.addFunction("Accept", &OsmLuaProcessing::Accept)
-		.addFunction("NextRelation", &OsmLuaProcessing::NextRelation)
-		.addFunction("RestartRelations", &OsmLuaProcessing::RestartRelations)
-		.addFunction("FindInRelation", &OsmLuaProcessing::FindInRelation)
+
+	osmLuaProcessing = this;
+	luaState["Id"] = &rawId;
+	luaState["Holds"] = &rawHolds;
+	luaState["Find"] = &rawFind;
+	luaState["FindIntersecting"] = &rawFindIntersecting;
+	luaState["Intersects"] = &rawIntersects;
+	luaState["FindCovering"] = &rawFindCovering;
+	luaState["CoveredBy"] = &rawCoveredBy;
+	luaState["IsClosed"] = &rawIsClosed;
+	luaState["Area"] = &rawArea;
+	luaState["AreaIntersecting"] = &rawAreaIntersecting;
+	luaState["Length"] = &rawLength;
+	luaState["Centroid"] = &rawCentroid;
+	luaState["Layer"] = &rawLayer;
+	luaState["LayerAsCentroid"] = &rawLayerAsCentroid;
+	luaState["Attribute"] = kaguya::overload(
+			[](const std::string &key, const std::string& val) { osmLuaProcessing->Attribute(key, val); },
+			[](const std::string &key, const std::string& val, const char minzoom) { osmLuaProcessing->AttributeWithMinZoom(key, val, minzoom); }
 	);
+	luaState["AttributeNumeric"] = kaguya::overload(
+			[](const std::string &key, const float val) { osmLuaProcessing->AttributeNumeric(key, val); },
+			[](const std::string &key, const float val, const char minzoom) { osmLuaProcessing->AttributeNumericWithMinZoom(key, val, minzoom); }
+	);
+	luaState["AttributeBoolean"] = kaguya::overload(
+			[](const std::string &key, const bool val) { osmLuaProcessing->AttributeBoolean(key, val); },
+			[](const std::string &key, const bool val, const char minzoom) { osmLuaProcessing->AttributeBooleanWithMinZoom(key, val, minzoom); }
+	);
+
+	luaState["MinZoom"] = &rawMinZoom;
+	luaState["ZOrder"] = &rawZOrder;
+	luaState["Accept"] = &rawAccept;
+	luaState["NextRelation"] = &rawNextRelation;
+	luaState["RestartRelations"] = &rawRestartRelations;
+	luaState["FindInRelation"] = &rawFindInRelation;
 	supportsRemappingShapefiles = !!luaState["attribute_function"];
 	supportsReadingRelations    = !!luaState["relation_scan_function"];
 	supportsWritingRelations    = !!luaState["relation_function"];
@@ -533,7 +568,7 @@ bool OsmLuaProcessing::scanRelation(WayID id, const tag_map_t &tags) {
 	isRelation = true;
 	currentTags = &tags;
 	try {
-		luaState["relation_scan_function"](this);
+		luaState["relation_scan_function"]();
 	} catch(luaProcessingException &e) {
 		std::cerr << "Lua error on scanning relation " << originalOsmID << std::endl;
 		exit(1);
@@ -556,7 +591,7 @@ void OsmLuaProcessing::setNode(NodeID id, LatpLon node, const tag_map_t &tags) {
 
 	//Start Lua processing for node
 	try {
-		luaState["node_function"](this);
+		luaState["node_function"]();
 	} catch(luaProcessingException &e) {
 		std::cerr << "Lua error on node " << originalOsmID << std::endl;
 		exit(1);
@@ -604,7 +639,7 @@ void OsmLuaProcessing::setWay(WayID wayId, LatpLonVec const &llVec, const tag_ma
 		//Start Lua processing for way
 		try {
 			kaguya::LuaFunction way_function = luaState["way_function"];
-			kaguya::LuaRef ret = way_function(this);
+			kaguya::LuaRef ret = way_function();
 			assert(!ret);
 		} catch(luaProcessingException &e) {
 			std::cerr << "Lua error on way " << originalOsmID << std::endl;
@@ -635,7 +670,7 @@ void OsmLuaProcessing::setRelation(int64_t relationId, WayVec const &outerWayVec
 	// Start Lua processing for relation
 	if (!isNativeMP && !supportsWritingRelations) return;
 	try {
-		luaState[isNativeMP ? "way_function" : "relation_function"](this);
+		luaState[isNativeMP ? "way_function" : "relation_function"]();
 	} catch(luaProcessingException &e) {
 		std::cerr << "Lua error on relation " << originalOsmID << std::endl;
 		exit(1);


### PR DESCRIPTION
Currently, Tilemaker uses member functions for interop:

```lua
function node_function(node)
    node:Layer(...)
```

This PR changes Tilemaker to use global functions:

```lua
function node_function()
    Layer(...)
```

The chief rationale is performance. Every member function call needs to push an extra pointer onto the stack when crossing the Lua/C++ boundary.

Kaguya serializes this pointer as a Lua userdata. That means every call into Lua has to malloc some memory, and every call back from Lua has to dereference through this pointer.

And there are a lot of calls! For OMT on the GB extract, I counted ~1.4B calls from Lua into C++.

A secondary rationale is that a global function is a bit more honest. A user might believe that this is currently permissible:

```lua
last_node = nil
function node_function(node)
    if last_node ~= nil
        -- do something with last_node
    end

    -- save the current node for later, for some reason
    last_node = node
```

But in reality, the OSM objects we pass into Lua don't behave quite like Lua objects. They're backed by OsmLuaProcessing, who will move on, invalidating whatever the user thinks they've got a reference to.

This PR has a noticeable decrease in reading time for me, measured on the OMT profile for GB, on a 16-core computer:

Before:
```
real	1m28.230s
user	19m30.281s
sys	0m29.610s
```

After:
```
real	1m21.728s
user	17m27.150s
sys	0m32.668s
```

The tradeoffs:

- anyone with a custom Lua profile will need to update it, although the changes are fairly mechanical

- Tilemaker now reserves several functions in the global namespace, causing the potential for conflicts